### PR TITLE
attempt at fixing tab open blink

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -170,9 +170,9 @@ var iChrome = function(refresh) {
 		$("body").removeClass("unloaded");
 	}, 300);
 
-	setTimeout(function() {
+	// setTimeout(function() {
 		iChrome.deferred(refresh);
-	}, 400);
+	// }, 400);
 
 	localStorage.uses = (localStorage.uses || 0) + 1;
 


### PR DESCRIPTION
This is the "fix" I'm currently using to fix the background blink problem that occurs when the tab first loads.

The following file is changed:
- script.js

Description of changes:
- got rid of the timer seems to fix this blink issue.

Thoughts:
- this is by no means a comprehensive fix. The issue in question is the background image flashing (reloading) during loading, and I think a better fix would be to stop this specific behavior. However, I don't see any side effects with not having the timer, hence my current fix.

Best,

xkxx
