### PR TITLE
use flexbox to scale the list size of widgets in the variable layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1085,6 +1085,8 @@ body > .widgets-container {
 	min-width: 0;
 	position: absolute;
 	max-width: 100%!important;
+	display: flex;
+	flex-direction: column;
 }
 
 .medley .widgets-container > .widget:hover {

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -23,6 +23,7 @@
 	/ Widget Globals
 */
 .widget .header {
+	flex: 0 0 auto;
 	color: #666;
 	font-size: 16px;
 	margin-bottom: 10px;
@@ -488,7 +489,7 @@
 	margin: 0;
 	padding: 0;
 	margin: -15px;
-	max-height: 600px;
+	flex: 1 1 auto;
 	overflow-x: hidden;
 }
 
@@ -1319,7 +1320,7 @@
 	font-size: 0;
 	display: block;
 	overflow: auto;
-	max-height: 365px;
+	flex: 1 1 auto;
 }
 
 .apps .app {
@@ -2383,7 +2384,7 @@
 .twitter .tweets {
 	margin: -15px;
 	overflow: auto;
-	max-height: 600px;
+	flex: 1 1 auto;
 }
 
 .twitter .tweet {
@@ -2516,7 +2517,7 @@
 .drive .files {
 	margin: -15px;
 	overflow: auto;
-	max-height: 605px;
+	flex: 1 1 auto;
 }
 
 .drive .file {


### PR DESCRIPTION
Thanks for the awesome new tab page! When i switched to the "grid" layout, I noticed that I could extend the height of the twitter widget, but that the list didn't adjust in size appropriately (see the screenshots below). 

When I went looking through the css I updated several other widgets to have the same behavior, but was not able to verify that all of them work as expected.

**Before:**
![image](https://cloud.githubusercontent.com/assets/1329312/5034655/f49245d2-6b2d-11e4-9edc-7aec05976cb0.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/1329312/5034647/ea4a768a-6b2d-11e4-9102-5d5cad1d74f3.png)
