### PR TITLE
Fix link in RSS widget

### DIFF
--- a/app/widgets/rss.js
+++ b/app/widgets/rss.js
@@ -120,7 +120,7 @@ define(["jquery"], function($) {
 				"</div>"),
 				item = {
 					title: itm.find("title").text().trim(),
-					url: (itm.find("link[href]").attr("href") || itm.find("link").text() || "").trim()
+					url: (itm.find("link").text() || itm.find("link[href]").attr("href") || "").trim()
 				};
 
 


### PR DESCRIPTION
* First search for ``<link>...</link>`` - is used in RSS (see [spec](http://web.resource.org/rss/1.0/spec#s5.5.2))
* Then search for ``<link href="" />`` or ``<atom:link href="" />`` - is used in Atom (see [spec](http://tools.ietf.org/html/rfc4287#section-4.2.7.1))

Due to a [bug](http://bugs.jquery.com/ticket/4208) in jQuery, the selector ``link[href]`` matches both ``atom:link`` and ``link``. This would cause issues in the following case:

```xml
<item>
  <title>...</title>
  <link>...</link>
  <description>...</description>
  <atom:link href="..." rel="related"></atom:link>
</item>
```

Here, the old code would set the related link as the URL for the article, instead of the actual link to the article.
