### PR TITLE
Improved image href parsing in feedly.js

### DIFF
--- a/app/widgets/feedly.js
+++ b/app/widgets/feedly.js
@@ -512,6 +512,14 @@ define(["jquery", "moment", "oauth"], function($, moment, OAuth) {
 					else if (image && image.indexOf("http://img.gawkerassets.com/") !== -1) {
 						image = image.replace("ku-xlarge", "ku-medium");
 					}
+					else if (article.enclosure) { //checks if the enclosure object exist, then if it contains an image it uses the first found
+						for (var i = 0; i < article.enclosure.length; i++) {
+							if (["image/jpeg", "image/png"].indexOf(article.enclosure[i].type) >= 0) {
+								image = article.enclosure[i].href;
+								break;
+							} 
+						}
+					}
 
 					return image;
 				},
@@ -561,7 +569,15 @@ define(["jquery", "moment", "oauth"], function($, moment, OAuth) {
 				if (e.origin) {
 					article.source = names[e.origin.streamId || ""] || e.origin.title || e.title;
 				}
+				
+				if (e.enclosure) { //sometime this object contains the image
+					article.enclosure = e.enclosure;
+				}
 
+				if (e.visual) {
+					article.visual = e.visual;
+				}
+				
 				article.image = getImage(article);
 
 				articles.push(article);


### PR DESCRIPTION
The algorithm had a tendency to miss hrefs located in the e.visual and e.enclosure objects, this fix it. 

before: 
![image](https://cloud.githubusercontent.com/assets/4585690/7317241/fd314db6-ea7e-11e4-8566-65ec1d38f71d.png)



after: 
![image](https://cloud.githubusercontent.com/assets/4585690/7317233/eb8490b4-ea7e-11e4-899c-21e31021e08a.png)






Signed-off-by: Mattia Di Eleuterio <madiele92@gmail.com>