### PR TITLE
fixed a bug where moving the widget would spam setInterval() instances

### DIFF
--- a/app/widgets/clock.js
+++ b/app/widgets/clock.js
@@ -97,7 +97,9 @@ define(["jquery", "lodash", "moment", "backbone"], function($, _, moment, Backbo
 			"click .alarm .set": "startAlarm"
 		},
 
-		interval: null,
+		intervalUpdateClock: null,
+		intervalUpdate: null,
+		intervalUpdateStopwatch: null,
 
 		formatTime: function(rTime, ms) {
 			var time = Math.floor(rTime / 1000);
@@ -359,7 +361,9 @@ define(["jquery", "lodash", "moment", "backbone"], function($, _, moment, Backbo
 		},
 
 		render: function() {
-			clearInterval(this.interval);
+			if (this.intervalUpdateClock) clearInterval(this.intervalUpdateClock);
+			if (this.intervalUpdate) clearInterval(this.intervalUpdate);
+			if (this.intervalUpdateStopwatch) clearInterval(this.intervalUpdateStopwatch);
 
 			this.isAnalog = (this.config.format == "analog");
 
@@ -434,19 +438,19 @@ define(["jquery", "lodash", "moment", "backbone"], function($, _, moment, Backbo
 			this.clockElm = this.$(".clock")[0];
 
 			if (this.config.size === "tiny") {
-				this.interval = setInterval(this.updateClock.bind(this), 1000);
+				this.intervalUpdateClock = setInterval(this.updateClock.bind(this), 1000);
 			}
 			else {
 				this.setCache();
 
-				this.interval = setInterval(this.update.bind(this), 1000);
+				this.intervalUpdate = setInterval(this.update.bind(this), 1000);
 
 				// The stopwatch displays milliseconds so it needs to update every ~50 ms
 				// instead of every 1000 to display a smooth progression
 				// 
 				// This uses 53 instead of 50 so the numbers displayed aren't continuously
 				// repeated
-				this.interval = setInterval(this.updateStopwatch.bind(this), 53);
+				this.intervalUpdateStopwatch = setInterval(this.updateStopwatch.bind(this), 53);
 			}
 		}
 	});

--- a/app/widgets/stats.js
+++ b/app/widgets/stats.js
@@ -163,6 +163,7 @@ define(["lodash", "jquery", "moment", "browser/api"], function(_, $, moment, Bro
 		},
 
 		render: function(demo) {
+			if (this.cpuInterval) clearInterval(this.cpuInterval);	
 			if (demo) this.refresh();
 
 			this.utils.render(this.data);


### PR DESCRIPTION
when moving the widget the render function was called and a new setInterval()
created, without clearing the old one, this caused the stats widget to go crazy
if moved too much and it also caused an extreme use of the cpu, a similar bug was
also in the clock widget.