### PR TITLE
remove the distracting icon that shows up whenever you open a new tab

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -47,7 +47,6 @@
 				}
 			</style>
 
-			<img src="icon/128.png" />
 		</div>
 
 		<link href="css/style.css?__NO_CACHE__" rel="stylesheet" />


### PR DESCRIPTION
The icon that shows up every time you open a new tab is extremely distracting, imposes cognitive load, grabs attention, and adds no value whatsoever - the end user is already well aware that they are using your extension. This commit removes it.