### PR TITLE
Twitter: Add photo preview

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -9840,6 +9840,9 @@ body.no-edit .bookmarks .tools {
 /*---------------------------------------------
 	/ Twitter
 */
+.widgets-container section.twitter.widget {
+	z-index: 8;
+}
 /* line 2417, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tweet {
 	color: #777;
@@ -9916,9 +9919,7 @@ body.no-edit .bookmarks .tools {
 
 /* line 2478, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tweet img {
-	float: left;
 	border-radius: 3px;
-	margin: 4px 15px 4px 0;
 }
 
 /* line 2484, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
@@ -9927,6 +9928,7 @@ body.no-edit .bookmarks .tools {
 	margin-top: 5px;
 	text-align: right;
 	margin-bottom: -7px;
+	clear: both;
 }
 
 /* line 2491, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
@@ -9979,6 +9981,40 @@ body.no-edit .bookmarks .tools {
 /* line 2530, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tools .more {
 	float: left;
+}
+
+.twitter .profile {
+	width: 50px;
+	margin: 4px 15px 4px 0;
+	float:left;
+}
+
+.twitter .content {
+	padding-left: 65px;
+}
+
+.twitter .media .thumbnail {
+    width: 25%;
+    margin: 3px;
+    vertical-align: baseline;
+}
+
+
+.twitter .media-preview-container {
+    z-index: 99;
+    position: fixed;
+    top: 10%;
+    left: 50%;
+    display: none;
+}
+
+.twitter .media-preview {
+	position:relative;
+	left:-50%;
+	border-radius: 3px;
+	border: 7px solid white;
+	max-height:80vh;
+	max-width:80vw;
 }
 
 /*---------------------------------------------

--- a/app/css/widgets.css
+++ b/app/css/widgets.css
@@ -2690,6 +2690,9 @@ body.no-edit .bookmarks .tools {
 /*---------------------------------------------
 	/ Twitter
 */
+.widgets-container section.twitter.widget {
+	z-index: 8;
+}
 /* line 2417, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tweet {
 	color: #777;
@@ -2766,9 +2769,7 @@ body.no-edit .bookmarks .tools {
 
 /* line 2478, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tweet img {
-	float: left;
 	border-radius: 3px;
-	margin: 4px 15px 4px 0;
 }
 
 /* line 2484, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
@@ -2777,6 +2778,7 @@ body.no-edit .bookmarks .tools {
 	margin-top: 5px;
 	text-align: right;
 	margin-bottom: -7px;
+	clear: both;
 }
 
 /* line 2491, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
@@ -2829,6 +2831,40 @@ body.no-edit .bookmarks .tools {
 /* line 2530, C:/Users/Avi/Documents/GitHub/iChrome/app/css/widgets.scss */
 .twitter .tools .more {
 	float: left;
+}
+
+.twitter .profile {
+	width: 50px;
+	margin: 4px 15px 4px 0;
+	float:left;
+}
+
+.twitter .content {
+	padding-left: 65px;
+}
+
+.twitter .media .thumbnail {
+    width: 25%;
+    margin: 3px;
+    vertical-align: baseline;
+}
+
+
+.twitter .media-preview-container {
+    z-index: 99;
+    position: fixed;
+    top: 10%;
+    left: 50%;
+    display: none;
+}
+
+.twitter .media-preview {
+	position:relative;
+	left:-50%;
+	border-radius: 3px;
+	border: 7px solid white;
+	max-height:80vh;
+	max-width:80vw;
 }
 
 /*---------------------------------------------

--- a/app/css/widgets.scss
+++ b/app/css/widgets.scss
@@ -2414,6 +2414,10 @@ body.no-edit .bookmarks .tools {
 /*---------------------------------------------
 	/ Twitter
 */
+.widgets-container section.twitter.widget {
+	z-index: 8;
+}
+
 .twitter .tweet {
 	color: #777;
 	padding: 15px;
@@ -2476,9 +2480,7 @@ body.no-edit .bookmarks .tools {
 }
 
 .twitter .tweet img {
-	float: left;
 	border-radius: 3px;
-	margin: 4px 15px 4px 0;
 }
 
 .twitter .tweet .tools {
@@ -2486,6 +2488,7 @@ body.no-edit .bookmarks .tools {
 	margin-top: 5px;
 	text-align: right;
 	margin-bottom: -7px;
+	clear: both;
 }
 
 .twitter .tools a {
@@ -2531,9 +2534,39 @@ body.no-edit .bookmarks .tools {
 	float: left;
 }
 
+.twitter .profile {
+	width: 50px;
+	margin: 4px 15px 4px 0;
+	float:left;
+}
+
+.twitter .content {
+	padding-left: 65px;
+}
+
+.twitter .media .thumbnail {
+    width: 25%;
+    margin: 3px;
+    vertical-align: baseline;
+}
 
 
+.twitter .media-preview-container {
+    z-index: 99;
+    position: fixed;
+    top: 10%;
+    left: 50%;
+    display: none;
+}
 
+.twitter .media-preview {
+	position:relative;
+	left:-50%;
+	border-radius: 3px;
+	border: 7px solid white;
+	max-height:80vh;
+	max-width:80vw;
+}
 
 /*---------------------------------------------
 	/ Twitter / Authorize & No Tweets

--- a/app/templates/widgets/twitter/template.hjs
+++ b/app/templates/widgets/twitter/template.hjs
@@ -8,10 +8,19 @@
 				<span class="age">{{age}}</span>
 			</div>
 
+			<div class="profile"><a href="https://twitter.com/{{username}}" class="user"><img src="{{image}}" /></a></div>
 			<div class="content">
-				<a href="https://twitter.com/{{username}}" class="user"><img src="{{image}}" /></a>
+
 
 				{{{content}}}
+
+				<div class="media">
+				{{#media}}
+					{{#photos}}
+					<img src="{{media_url_https}}:thumb" class="thumbnail" />
+					{{/photos}}
+				{{/media}}
+				</div>
 			</div>
 
 			<div class="tools">
@@ -35,4 +44,8 @@
 			</div>
 		{{/authorize}}
 	{{/tweets}}
+
+	<div class="media-preview-container">
+		<img src="" class="media-preview" />
+	</div>
 </div>

--- a/app/widgets/twitter.js
+++ b/app/widgets/twitter.js
@@ -41,6 +41,46 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 				{
 					id: "453275760728367104",
 					content: "Video: What are Games Developers looking for in the Cloud? <a href=\"http://t.co/V4qdADsn5m\" target=\"_blank\">goo.gl/R9Strw</a>  /by <a href=\"http://www.twitter.com/tekgrrl\" target=\"_blank\" title=\"Mandy Waite\">@tekgrrl</a> <a href=\"http://www.twitter.com/search?q=%23gaming&amp;src=hash\" target=\"_blank\">#gaming</a> <a href=\"http://www.twitter.com/search?q=%23cloud&amp;src=hash\" target=\"_blank\">#cloud</a> <a href=\"http://www.twitter.com/search?q=%23developers&amp;src=hash\" target=\"_blank\">#developers</a>",
+					media: {
+						photos: [
+						                {
+						                    "id": 868394997854425088,
+						                    "id_str": "868394997854425088",
+						                    "indices": [
+						                        115,
+						                        138
+						                    ],
+						                    "media_url": "http://pbs.twimg.com/media/DA0opkvW0AAqYAW.jpg",
+						                    "media_url_https": "https://pbs.twimg.com/media/DA0opkvW0AAqYAW.jpg",
+						                    "url": "https://t.co/gdtLoxDDj5",
+						                    "display_url": "pic.twitter.com/gdtLoxDDj5",
+						                    "expanded_url": "https://twitter.com/Thom_astro/status/868437882670694401/photo/1",
+						                    "type": "photo",
+						                    "sizes": {
+						                        "small": {
+						                            "w": 680,
+						                            "h": 453,
+						                            "resize": "fit"
+						                        },
+						                        "thumb": {
+						                            "w": 150,
+						                            "h": 150,
+						                            "resize": "crop"
+						                        },
+						                        "large": {
+						                            "w": 1024,
+						                            "h": 682,
+						                            "resize": "fit"
+						                        },
+						                        "medium": {
+						                            "w": 1024,
+						                            "h": 682,
+						                            "resize": "fit"
+						                        }
+						                    }
+						                }
+						        ],
+						},
 					user: "Google Developers",
 					username: "googledevs",
 					image: "https://pbs.twimg.com/profile_images/440636713354817536/I_Z3SDmE_normal.png",
@@ -49,6 +89,7 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 				{
 					id: "453275245143916545",
 					content: "Explore archives &amp; exhibits about Tezuka Osamu, the godfather of <a href=\"http://www.twitter.com/search?q=%23manga&amp;src=hash\" target=\"_blank\">#manga</a>. <a href=\"http://t.co/QyYNRCnmuf\" target=\"_blank\">goo.gl/LeHLIa</a>",
+					media: {photos:[]},
 					user: "A Googler",
 					username: "google",
 					image: "https://pbs.twimg.com/profile_images/2504370963/6u5qf6cl9jtwew6poxcj_normal.png",
@@ -57,6 +98,7 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 				{
 					id: "453238414838493185",
 					content: "New video from <a href=\"http://www.twitter.com/ade_oshineye\" target=\"_blank\" title=\"Adewale Oshineye\">@ade_oshineye</a>: Grow with Google(+) <a href=\"http://t.co/uuyw94RFFh\" target=\"_blank\">goo.gl/5lU7Hs</a>",
+					media: {photos:[]},
 					user: "Google Developers",
 					username: "googledevs",
 					image: "https://pbs.twimg.com/profile_images/440636713354817536/I_Z3SDmE_normal.png",
@@ -65,6 +107,7 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 				{
 					id: "452513890287370241",
 					content: "RT <a href=\"http://www.twitter.com/jaffathecake\" target=\"_blank\" title=\"Jake Archibald\">@jaffathecake</a>: The Extensible Web Summit was bloody great &amp; should be done again. Notes at <a href=\"http://t.co/wdQIaH9G6i\" target=\"_blank\">lanyrd.com/2014/extensibl…</a> - nice one <a href=\"http://www.twitter.com/torgo\" target=\"_blank\" title=\"Daniel Appelquist\">@torgo</a> <a href=\"http://www.twitter.com/annevk\" target=\"_blank\" title=\"Anne van Kesteren\">@annevk</a> <a href=\"http://www.twitter.com/domenic\" target=\"_blank\" title=\"Domenic Denicola\">@domenic</a> et al",
+					media: {photos:[]},
 					user: "Google Developers",
 					username: "googledevs",
 					image: "https://pbs.twimg.com/profile_images/440636713354817536/I_Z3SDmE_normal.png",
@@ -73,6 +116,7 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 				{
 					id: "452161945513103360",
 					content: "RT <a href=\"http://www.twitter.com/addyosmani\" target=\"_blank\" title=\"Addy Osmani\">@addyosmani</a>: Writing Accessible Web Components: <a href=\"http://t.co/Tlkl7ucRsK\" target=\"_blank\">polymer-project.org/articles/acces…</a> - Part 1 of a new guide by <a href=\"http://www.twitter.com/sundress\" target=\"_blank\" title=\"Alice Boxhall\">@sundress</a> and I. <a href=\"http://www.twitter.com/search?q=%23a11y&amp;src=hash\" target=\"_blank\">#a11y</a>",
+					media: {photos:[]},
 					user: "Google Developers",
 					username: "googledevs",
 					image: "https://pbs.twimg.com/profile_images/440636713354817536/I_Z3SDmE_normal.png",
@@ -363,6 +407,7 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 							var tweet = {
 								id: e.id_str,
 								content: (retweet ? retweet.text : e.text),
+								media: {photos: []},
 								user: e.user.name,
 								username: e.user.screen_name,
 								image: e.user.profile_image_url_https,
@@ -370,6 +415,16 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 							};
 
 							var replaces = [];
+
+							var media = (retweet ? retweet.entities.media : e.entities.media);
+							if(media){
+								media.forEach(function(entity){
+									if(entity.type === "photo"){
+										tweet.media.photos.push(entity);
+										replaces.push({loc: entity.indices, text: ""});
+									}
+								});
+							}
 
 							(retweet ? retweet.entities : e.entities).hashtags.forEach(function(e) {
 								replaces.push({
@@ -459,6 +514,23 @@ define(["jquery", "moment", "browser/api"], function($, moment, Browser) {
 			}
 
 			this.utils.render(data);
+
+			if(!this.handlersRegistered){
+				$(this.elm).on("click", ".thumbnail", function(event){
+					event.stopPropagation();
+					var src = this.getAttribute("src");
+					$(".media-preview").attr("src", src.substr(0, src.length - 6));
+					$(".media-preview-container").fadeToggle();
+				});
+
+				$(this.elm).on("click", ".media-preview-container", function(event){
+					event.stopPropagation();
+					$(this).fadeOut();
+				});
+
+				this.handlersRegistered = true;
+			}
+
 		}
 	};
 });


### PR DESCRIPTION
I've added a photo-preview for tweets. Unfortunately I could not test the part in the `refresh` method, because I don't have a dev token for twitter, but I guess it should be fine. If this is merged, I might add video and citation preview as well.
I did not do anything to include it in the new tab-page, so if that is not just a wrapper of some sort around the ichrome homepage, that would have to be done still.